### PR TITLE
Add LensID in possible tag values

### DIFF
--- a/src/main/java/com/thebuzzmedia/exiftool/ExifTool.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/ExifTool.java
@@ -746,7 +746,7 @@ public class ExifTool {
 				"GPSDestBearing", Double.class), GPS_BEARING_REF(
 				"GPSDestBearingRef", String.class), GPS_TIMESTAMP(
 				"GPSTimeStamp", String.class), ROTATION("Rotation",Integer.class),
-				EXIF_VERSION("ExifVersion",String.class);
+				EXIF_VERSION("ExifVersion",String.class), LENS_ID("LensID",String.class);
 
 		private static final Map<String, Tag> TAG_LOOKUP_MAP;
 


### PR DESCRIPTION
LensID is a tag that provide information to identify lens type.
For example, "241" means "Canon EF 50mm F1.2L USM".
It's not always a numerical identifier, it can be a string that give informations about the lens type.
Be careful, lens id is not always specified in exif metadatas.
